### PR TITLE
Replace Keepass with KeepassXC

### DIFF
--- a/source/team/password-manager.rst
+++ b/source/team/password-manager.rst
@@ -34,7 +34,7 @@ Links:
 
 
 
-- `KeePassX <https://www.keepassx.org/>`_
+- `KeePassXC <https://keepassxc.org/>`_
 
 
 


### PR DESCRIPTION
Development on Keepass has stopped as of Dec 21 ([source](https://www.keepassx.org/index.html%3Fp=636.html)), the developer suggests the community fork [KeepassXC](https://keepassxc.org) which is actively maintained.